### PR TITLE
Add option to set DB_PROVIDER from env

### DIFF
--- a/mirrorcache/common-conf.sls
+++ b/mirrorcache/common-conf.sls
@@ -1,5 +1,17 @@
 {% from "mirrorcache/macros.jinja" import var_if_pillar with context -%}
 
+{% set db_provider = 'mariadb' %}
+{% set db_provider_from_pillar = salt['pillar.get']('mirrorcache:db_provider') %}
+{% if db_provider_from_pillar %}
+  {% set db_provider = db_provider_from_pillar %}
+{% else %}
+  {% set db_provider_from_env = salt['environ.get']('MIRRORCACHE_DB_PROVIDER') %}
+  {% if db_provider_from_env %}
+    {% set db_provider = db_provider_from_env %}
+  {% endif %}
+{% endif %}
+
+
 common.conf.env:
   file.keyvalue:
     - name: /etc/mirrorcache/conf.env
@@ -8,11 +20,9 @@ common.conf.env:
     - key_values:
         {{ var_if_pillar('root',     'http://download.opensuse.org') -}}
         {{ var_if_pillar('root_nfs', '') -}}
-        {{ var_if_pillar('db_provider', 'mariadb') -}}
+        MIRRORCACHE_DB_PROVIDER: {{ db_provider }}
         MIRRORCACHE_DBHOST: '{{ salt['pillar.get']('mirrorcache:db:host', '') }}'
         MIRRORCACHE_DBUSER: 'mirrorcache'
         MIRRORCACHE_DBPASS: '{{ salt['pillar.get']('mysql:user:mirrorcache:password', '') }}'
         MOJO_PUBSUB_EXPERIMENTAL: '1'
-
-
 

--- a/t/12-mirrorcache-backstage-psql.sh
+++ b/t/12-mirrorcache-backstage-psql.sh
@@ -7,10 +7,11 @@ mkdir -p /srv/pillar
 echo "
 mirrorcache:
   root: /srv/mirrorcache/dt
-  db_provider: postgresql
   hashes_collect: 1
   zsync_collect: dat
 " > /srv/pillar/testpreset.sls
+
+export MIRRORCACHE_DB_PROVIDER=postgresql
 
 salt-call --local state.apply 'mirrorcache.postgres'
 salt-call --local state.apply 'mirrorcache.backstage' -l debug


### PR DESCRIPTION
Setting pillar is not always convenient, so fallback to environmane variable if no pillar