### PR TITLE
Dual stack listener

### DIFF
--- a/mirrorcache/webui-conf.sls
+++ b/mirrorcache/webui-conf.sls
@@ -12,7 +12,7 @@ webui.conf.env:
     - key_values:
         MIRRORCACHE_INI: /etc/mirrorcache/conf.ini
         MIRRORCACHE_METALINK_GREEDY: '3'
-        MOJO_LISTEN: 'http://*:3000'
+        MOJO_LISTEN: 'http://[::]:3000'
         MOJO_REVERSE_PROXY: '1'
         {{ var_if_pillar('workers',      '') }}
         {{ var_if_pillar('proxy_url',    '') }}


### PR DESCRIPTION
"*" in Mojo will try to bind to single stack IPv4 and fail on IPv6 only machines, as are used in the openSUSE infrastructure. Using "::" will open a dual stack listener which should facilitate both environments equally.